### PR TITLE
use pkexec for Decky plugin management

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -1,5 +1,29 @@
 # vim: set ft=make :
 
+_decky_helpers := '''
+# resolves the real invoking user when elevated with pkexec/sudo, else falls back to $UID
+_resolve_target_uid() {
+  if [[ -n "${PKEXEC_UID:-}" ]]; then echo "$PKEXEC_UID"
+  elif [[ -n "${SUDO_UID:-}" ]]; then echo "$SUDO_UID"
+  else echo "$UID"; fi
+}
+_resolve_target_user() { id -nu "$(_resolve_target_uid)"; }
+_resolve_target_home() { getent passwd "$(_resolve_target_user)" | cut -d: -f6; }
+
+# path helpers (do not assume ~ expands under pkexec)
+_plugins_dir() { echo "$(_resolve_target_home)/homebrew/plugins"; }
+
+# run a command as root using polkit; error out cleanly if polkit is missing/denied
+_as_root() {
+  if ! command -v pkexec >/dev/null 2>&1; then
+    echo "pkexec not found; cannot write to root-owned Homebrew." >&2
+    return 127
+  fi
+  # Use bash -lc so we can pass pipelines/heredocs safely
+  pkexec /usr/bin/bash -lc "$*"
+}
+'''
+
 # Install System Flatpaks (Support for Rebasing)
 _install-system-flatpaks:
     #!/usr/bin/bash
@@ -273,6 +297,7 @@ configure-watchdog ACTION="":
 # Install and configure Decky Loader (https://github.com/SteamDeckHomebrew/decky-loader) and plugins for alternative handhelds
 setup-decky ACTION="":
     #!/usr/bin/bash
+    {{_decky_helpers}}
     if [[ $(id -u) -eq 0 ]]; then
         echo >&2 "ERROR: Do not run this with sudo"
         exit 1
@@ -283,30 +308,29 @@ setup-decky ACTION="":
       DECKY_STATE="${b}${green}Installed${n}"
     fi
     install_release() {
-      export HOME=$(getent passwd ${SUDO_USER:-$USER} | cut -d: -f6)
+      export HOME="$(_resolve_target_home)"
       if [ ! -L "/home/deck" ] && [ ! -e "/home/deck" ]  && [ "$HOME" != "/home/deck" ]; then
         echo "Making a /home/deck symlink to fix plugins that do not use environment variables."
-        sudo -A ln -sf "$HOME" /home/deck
-      fi
-      if [[ -d ~/homebrew ]]; then
-        sudo -A chown -R --reference ~/ ~/homebrew
+        _as_root "ln -sf \"$HOME\" /home/deck" || { echo "Failed to create /home/deck symlink" >&2; exit $?; }
       fi
       curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh |
-        sed 's|sudo|sudo -A |g' | sh
-      sudo -A chcon -R -t bin_t $HOME/homebrew/services/PluginLoader
+        sed 's|sudo|pkexec|g' | bash
+      _as_root "chcon -R -t bin_t \"$HOME/homebrew/services/PluginLoader\"" || { echo "Failed to set SELinux context" >&2; exit $?; }
     }
     install_prerelease() {
-      export HOME=$(getent passwd ${SUDO_USER:-$USER} | cut -d: -f6)
+      export HOME="$(_resolve_target_home)"
       if [ ! -L "/home/deck" ] && [ ! -e "/home/deck" ]  && [ "$HOME" != "/home/deck" ]; then
         echo "Making a /home/deck symlink to fix plugins that do not use environment variables."
-        sudo -A ln -sf "$HOME" /home/deck
+        _as_root "ln -sf \"$HOME\" /home/deck" || { echo "Failed to create /home/deck symlink" >&2; exit $?; }
       fi
-      curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_prerelease.sh | sh
-      sudo -A chcon -R -t bin_t $HOME/homebrew/services/PluginLoader
+      curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_prerelease.sh |
+        sed 's|sudo|pkexec|g' | bash
+      _as_root "chcon -R -t bin_t \"$HOME/homebrew/services/PluginLoader\"" || { echo "Failed to set SELinux context" >&2; exit $?; }
     }
     uninstall() {
       echo "Uninstalling Decky Loader..."
-      curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/uninstall.sh | sh
+      curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/uninstall.sh |
+        sed 's|sudo|pkexec|g' | bash
       echo "Decky Loader has been uninstalled."
     }
     OPTION={{ ACTION }}
@@ -590,21 +614,16 @@ toggle-password-feedback ACTION="":
 get-decky-bazzite-buddy:
     #!/bin/bash
     set -euo pipefail
+    {{_decky_helpers}}
     REPO_OWNER="xXJSONDeruloXx"
     REPO_NAME="bazzite-buddy"
     PLUGIN_NAME="bazzite-buddy"
-    PLUGIN_DIR="$HOME/homebrew/plugins"
+    PLUGIN_DIR="$(_plugins_dir)"
 
     # Check if Decky is installed
-    if [ ! -d "$HOME/homebrew" ]; then
+    if [ ! -d "$(_resolve_target_home)/homebrew" ]; then
       echo "Error: Decky Loader is not installed. Please run 'ujust setup-decky install' first."
       exit 1
-    fi
-
-    # Fix ownership of homebrew plugins directory if it exists but is owned by root
-    if [ -d "$HOME/homebrew/plugins" ] && [ ! -w "$HOME/homebrew/plugins" ]; then
-      echo "Fixing ownership of plugins directory..."
-      sudo chown -R $(whoami):$(whoami) "$HOME/homebrew/plugins"
     fi
 
     # Get the latest release information with timeout
@@ -628,16 +647,10 @@ get-decky-bazzite-buddy:
       echo "Found latest release: $PLUGIN_URL"
     fi
 
-    # Ensure plugins directory exists and has correct permissions
+    # Ensure plugins directory exists
     if [ ! -d "$PLUGIN_DIR" ]; then
       echo "Creating plugins directory..."
-      mkdir -p "$PLUGIN_DIR"
-    fi
-
-    # Fix permissions on plugins directory if needed
-    if [ ! -w "$PLUGIN_DIR" ]; then
-      echo "Fixing permissions on plugins directory..."
-      chmod u+w "$PLUGIN_DIR"
+      _as_root "mkdir -p \"$PLUGIN_DIR\"" || { echo "Failed to create plugins directory" >&2; exit $?; }
     fi
 
     # Work in a temporary directory to avoid permission issues
@@ -647,7 +660,7 @@ get-decky-bazzite-buddy:
     # Remove any existing plugin folder
     if [ -d "$PLUGIN_DIR/$PLUGIN_NAME" ]; then
       echo "Removing existing $PLUGIN_NAME directory..."
-      rm -rf "$PLUGIN_DIR/$PLUGIN_NAME"
+      _as_root "rm -rf \"$PLUGIN_DIR/$PLUGIN_NAME\"" || { echo "Failed to remove existing plugin" >&2; exit $?; }
     fi
 
     # Download the zip file
@@ -698,13 +711,13 @@ get-decky-bazzite-buddy:
     # Move plugin to final location
     if [ -d "./$PLUGIN_NAME" ]; then
       echo "Installing plugin to $PLUGIN_DIR..."
-      mv "./$PLUGIN_NAME" "$PLUGIN_DIR/"
+      _as_root "mv \"./$PLUGIN_NAME\" \"$PLUGIN_DIR/\"" || { echo "Failed to install plugin" >&2; exit $?; }
 
       # Fix permissions on plugin files and make scripts executable
       echo "Setting correct permissions..."
-      chmod -R u+w "$PLUGIN_DIR/$PLUGIN_NAME"
-      find "$PLUGIN_DIR/$PLUGIN_NAME" -name "*.sh" -exec chmod +x {} \;
-      find "$PLUGIN_DIR/$PLUGIN_NAME" -name "*.py" -exec chmod +x {} \;
+      _as_root "chmod -R u+rwX \"$PLUGIN_DIR/$PLUGIN_NAME\"" || { echo "Failed to set permissions" >&2; exit $?; }
+      _as_root "find \"$PLUGIN_DIR/$PLUGIN_NAME\" -name '*.sh' -exec chmod +x {} \;" || { echo "Failed to mark scripts executable" >&2; exit $?; }
+      _as_root "find \"$PLUGIN_DIR/$PLUGIN_NAME\" -name '*.py' -exec chmod +x {} \;" || { echo "Failed to mark scripts executable" >&2; exit $?; }
 
       echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
       echo "Please restart Decky Loader to activate the plugin."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -1,8 +1,33 @@
 # vim: set ft=make :
 
+_decky_helpers := '''
+# resolves the real invoking user when elevated with pkexec/sudo, else falls back to $UID
+_resolve_target_uid() {
+  if [[ -n "${PKEXEC_UID:-}" ]]; then echo "$PKEXEC_UID"
+  elif [[ -n "${SUDO_UID:-}" ]]; then echo "$SUDO_UID"
+  else echo "$UID"; fi
+}
+_resolve_target_user() { id -nu "$(_resolve_target_uid)"; }
+_resolve_target_home() { getent passwd "$(_resolve_target_user)" | cut -d: -f6; }
+
+# path helpers (do not assume ~ expands under pkexec)
+_plugins_dir() { echo "$(_resolve_target_home)/homebrew/plugins"; }
+
+# run a command as root using polkit; error out cleanly if polkit is missing/denied
+_as_root() {
+  if ! command -v pkexec >/dev/null 2>&1; then
+    echo "pkexec not found; cannot write to root-owned Homebrew." >&2
+    return 127
+  fi
+  # Use bash -lc so we can pass pipelines/heredocs safely
+  pkexec /usr/bin/bash -lc "$*"
+}
+'''
+
 # Set up DLSS-Enabler Upscaling and Framegen mod. This mod replaces DLSS upscaling and frame generation with FSR3 equivalents in supported games.
 get-framegen ACTION="prompt":
     #!/usr/bin/bash
+    {{_decky_helpers}}
     source /usr/lib/ujust/ujust.sh
     FG_FILES=(
         "amd_fidelityfx_dx12.dll" "dlssg_to_fsr3_amd_is_better.dll" "libxess.dll"
@@ -34,7 +59,7 @@ get-framegen ACTION="prompt":
         fi
     }
     function check_decky_installed() {
-        PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
+        PLUGIN_DIR="$(_plugins_dir)/Decky-Framegen"
         if [[ -d "$PLUGIN_DIR" ]]; then
             echo "${green}${bold}Decky Framegen plugin is installed.${normal}"
         else
@@ -80,15 +105,9 @@ get-framegen ACTION="prompt":
         echo "Installing Decky Framegen plugin..."
 
         # Check if Decky is installed
-        if [ ! -d "$HOME/homebrew" ]; then
+        if [ ! -d "$(_resolve_target_home)/homebrew" ]; then
             echo "Error: Decky Loader is not installed. Please run 'ujust setup-decky install' first."
             exit 1
-        fi
-
-        # Fix ownership of homebrew plugins directory if it exists but is owned by root
-        if [ -d "$HOME/homebrew/plugins" ] && [ ! -w "$HOME/homebrew/plugins" ]; then
-            echo "Fixing ownership of plugins directory..."
-            sudo chown -R $(whoami):$(whoami) "$HOME/homebrew/plugins"
         fi
 
         API_URL="https://api.github.com/repos/xXJSONDeruloXx/Decky-Framegen/releases/latest"
@@ -100,18 +119,12 @@ get-framegen ACTION="prompt":
         fi
 
         PLUGIN_NAME="Decky-Framegen"
-        PLUGIN_DIR="$HOME/homebrew/plugins"
+        PLUGIN_DIR="$(_plugins_dir)"
 
-        # Ensure plugins directory exists and has correct permissions
+        # Ensure plugins directory exists
         if [ ! -d "$PLUGIN_DIR" ]; then
             echo "Creating plugins directory..."
-            mkdir -p "$PLUGIN_DIR"
-        fi
-
-        # Fix permissions on plugins directory if needed
-        if [ ! -w "$PLUGIN_DIR" ]; then
-            echo "Fixing permissions on plugins directory..."
-            chmod u+w "$PLUGIN_DIR"
+            _as_root "mkdir -p \"$PLUGIN_DIR\"" || { echo "Failed to create plugins directory" >&2; exit $?; }
         fi
 
         # Work in a temporary directory to avoid permission issues
@@ -121,7 +134,7 @@ get-framegen ACTION="prompt":
         # Remove any existing plugin folder
         if [ -d "$PLUGIN_DIR/$PLUGIN_NAME" ]; then
             echo "Removing existing $PLUGIN_NAME directory..."
-            rm -rf "$PLUGIN_DIR/$PLUGIN_NAME"
+            _as_root "rm -rf \"$PLUGIN_DIR/$PLUGIN_NAME\"" || { echo "Failed to remove existing plugin" >&2; exit $?; }
         fi
 
         echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
@@ -163,13 +176,13 @@ get-framegen ACTION="prompt":
         # Move plugin to final location
         if [ -d "./$PLUGIN_NAME" ]; then
             echo "Installing plugin to $PLUGIN_DIR..."
-            mv "./$PLUGIN_NAME" "$PLUGIN_DIR/"
+            _as_root "mv \"./$PLUGIN_NAME\" \"$PLUGIN_DIR/\"" || { echo "Failed to install plugin" >&2; exit $?; }
 
             # Fix permissions on plugin files and make scripts executable
             echo "Setting correct permissions..."
-            chmod -R u+w "$PLUGIN_DIR/$PLUGIN_NAME"
-            find "$PLUGIN_DIR/$PLUGIN_NAME" -name "*.sh" -exec chmod +x {} \;
-            find "$PLUGIN_DIR/$PLUGIN_NAME" -name "*.py" -exec chmod +x {} \;
+            _as_root "chmod -R u+rwX \"$PLUGIN_DIR/$PLUGIN_NAME\"" || { echo "Failed to set permissions" >&2; exit $?; }
+            _as_root "find \"$PLUGIN_DIR/$PLUGIN_NAME\" -name '*.sh' -exec chmod +x {} \;" || { echo "Failed to mark scripts executable" >&2; exit $?; }
+            _as_root "find \"$PLUGIN_DIR/$PLUGIN_NAME\" -name '*.py' -exec chmod +x {} \;" || { echo "Failed to mark scripts executable" >&2; exit $?; }
 
             echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
             echo "Please restart Decky Loader to activate the plugin."
@@ -207,6 +220,7 @@ get-framegen ACTION="prompt":
 # Set up Lossless Scaling vulkan layer and decky plugin. This mod enables lossless scaling compatibility in linux. Be sure to also install Lossless Scaling from Steam to internal storage.
 get-lsfg ACTION="prompt":
     #!/usr/bin/bash
+    {{_decky_helpers}}
     source /usr/lib/ujust/ujust.sh
 
     function check_lsfg_installed() {
@@ -222,7 +236,7 @@ get-lsfg ACTION="prompt":
     }
 
     function check_decky_lsfg_installed() {
-        PLUGIN_DIR="$HOME/homebrew/plugins/Lossless Scaling"
+        PLUGIN_DIR="$(_plugins_dir)/Lossless Scaling"
         if [[ -d "$PLUGIN_DIR" ]]; then
             echo "${green}${bold}Decky Lossless Scaling plugin is installed.${normal}"
         else
@@ -364,15 +378,9 @@ get-lsfg ACTION="prompt":
         echo "Installing Decky Lossless Scaling plugin..."
 
         # Check if Decky is installed
-        if [ ! -d "$HOME/homebrew" ]; then
+        if [ ! -d "$(_resolve_target_home)/homebrew" ]; then
             echo "Error: Decky Loader is not installed. Please run 'ujust setup-decky install' first."
             exit 1
-        fi
-
-        # Fix ownership of homebrew plugins directory if it exists but is owned by root
-        if [ -d "$HOME/homebrew/plugins" ] && [ ! -w "$HOME/homebrew/plugins" ]; then
-            echo "Fixing ownership of plugins directory..."
-            sudo chown -R $(whoami):$(whoami) "$HOME/homebrew/plugins"
         fi
 
         API_URL="https://api.github.com/repos/xXJSONDeruloXx/decky-lossless-scaling-vk/releases/latest"
@@ -384,18 +392,12 @@ get-lsfg ACTION="prompt":
         fi
 
         PLUGIN_NAME="Lossless-Scaling"
-        PLUGIN_DIR="$HOME/homebrew/plugins"
+        PLUGIN_DIR="$(_plugins_dir)"
 
-        # Ensure plugins directory exists and has correct permissions
+        # Ensure plugins directory exists
         if [ ! -d "$PLUGIN_DIR" ]; then
             echo "Creating plugins directory..."
-            mkdir -p "$PLUGIN_DIR"
-        fi
-
-        # Fix permissions on plugins directory if needed
-        if [ ! -w "$PLUGIN_DIR" ]; then
-            echo "Fixing permissions on plugins directory..."
-            chmod u+w "$PLUGIN_DIR"
+            _as_root "mkdir -p \"$PLUGIN_DIR\"" || { echo "Failed to create plugins directory" >&2; exit $?; }
         fi
 
         # Work in a temporary directory to avoid permission issues
@@ -405,15 +407,13 @@ get-lsfg ACTION="prompt":
         # Remove any existing plugin folder
         if [ -d "$PLUGIN_DIR/$PLUGIN_NAME" ]; then
             echo "Removing existing $PLUGIN_NAME directory..."
-            chmod -R u+w "$PLUGIN_DIR/$PLUGIN_NAME" 2>/dev/null || true
-            rm -rf "$PLUGIN_DIR/$PLUGIN_NAME"
+            _as_root "rm -rf \"$PLUGIN_DIR/$PLUGIN_NAME\"" || { echo "Failed to remove existing plugin" >&2; exit $?; }
         fi
 
-        # Also remove the expected final name in case it exists with different permissions
+        # Also remove the expected final name in case it exists
         if [ -d "$PLUGIN_DIR/Lossless Scaling" ]; then
             echo "Removing existing Lossless Scaling directory..."
-            chmod -R u+w "$PLUGIN_DIR/Lossless Scaling" 2>/dev/null || true
-            rm -rf "$PLUGIN_DIR/Lossless Scaling"
+            _as_root "rm -rf \"$PLUGIN_DIR/Lossless Scaling\"" || { echo "Failed to remove existing plugin" >&2; exit $?; }
         fi
 
         echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
@@ -455,13 +455,13 @@ get-lsfg ACTION="prompt":
         # Move plugin to final location
         if [ -d "./$PLUGIN_NAME" ]; then
             echo "Installing plugin to $PLUGIN_DIR..."
-            mv "./$PLUGIN_NAME" "$PLUGIN_DIR/Lossless Scaling"
+            _as_root "mv \"./$PLUGIN_NAME\" \"$PLUGIN_DIR/Lossless Scaling\"" || { echo "Failed to install plugin" >&2; exit $?; }
 
             # Fix permissions on plugin files and make scripts executable
             echo "Setting correct permissions..."
-            chmod -R u+w "$PLUGIN_DIR/Lossless Scaling"
-            find "$PLUGIN_DIR/Lossless Scaling" -name "*.sh" -exec chmod +x {} \;
-            find "$PLUGIN_DIR/Lossless Scaling" -name "*.py" -exec chmod +x {} \;
+            _as_root "chmod -R u+rwX \"$PLUGIN_DIR/Lossless Scaling\"" || { echo "Failed to set permissions" >&2; exit $?; }
+            _as_root "find \"$PLUGIN_DIR/Lossless Scaling\" -name '*.sh' -exec chmod +x {} \;" || { echo "Failed to mark scripts executable" >&2; exit $?; }
+            _as_root "find \"$PLUGIN_DIR/Lossless Scaling\" -name '*.py' -exec chmod +x {} \;" || { echo "Failed to mark scripts executable" >&2; exit $?; }
 
             echo "Lossless Scaling plugin has been installed successfully to $PLUGIN_DIR!"
             echo "Please restart Decky Loader to activate the plugin."


### PR DESCRIPTION
## Summary
- add pkexec helpers to resolve invoking user
- wrap Decky plugin installs with _as_root instead of chowning

## Testing
- `pre-commit run --files system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68979871f458832892e23d7389493251